### PR TITLE
LoggerProUpdate download version check regex

### DIFF
--- a/LoggerPro_Update/LoggerPro_Update.download.recipe
+++ b/LoggerPro_Update/LoggerPro_Update.download.recipe
@@ -16,7 +16,7 @@
 		<key>SEARCH_PATTERN_URL</key>
 		<string>href="(?P&lt;url&gt;.*\.dmg)"</string>
 		<key>SEARCH_PATTERN_VERSION</key>
-		<string>https://www2.vernier.com/updates/LoggerPro(?P&lt;url2&gt;[\_0-9]*)_.*</string>
+		<string>\"Logger Pro (?P&lt;version&gt;.*?) is the latest update to our award-winning data-collection software\.</string>
 		<key>USER_AGENT</key>
 		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
 	</dict>


### PR DESCRIPTION
They must have changed what's on the page, because the old regex was returning
```
Error in local.munki.LoggerPro_Update: Processor: URLTextSearcher: Error: No match found on URL: https://www.vernier.com/support/updates/logger-pro/
```