### PR TITLE
Logger Pro Munki recipe requires / installs array

### DIFF
--- a/LoggerPro_Update/LoggerPro_Update.munki.recipe
+++ b/LoggerPro_Update/LoggerPro_Update.munki.recipe
@@ -29,6 +29,29 @@
 				<dict>
 					<key>version</key>
 					<string>%dversion%</string>
+					<key>update_for</key>
+					<array>
+						<string>LoggerPro</string>
+					</array>
+					<key>installs</key>
+					<array>
+						<dict>
+							<key>CFBundleIdentifier</key>
+							<string>com.vernier.loggerpro</string>
+							<key>CFBundleName</key>
+							<string>Logger Pro</string>
+							<key>CFBundleShortVersionString</key>
+							<string>%dversion%</string>
+							<key>CFBundleVersion</key>
+							<string>%dversion%</string>
+							<key>path</key>
+							<string>/Applications/Logger Pro 3/Logger Pro.app</string>
+							<key>type</key>
+							<string>application</string>
+							<key>version_comparison_key</key>
+							<string>CFBundleShortVersionString</string>
+						</dict>
+					</array>
 				</dict>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>


### PR DESCRIPTION
Since the update leaves useless receipts (version 0), Munki thinks the update is already installed, so added an installs array with the new version number.

Since it's an update for a proper installation, added in a required key.