### PR TITLE
Munki Logger Pro installs array / requires

### DIFF
--- a/LoggerPro_Update/LoggerPro_Update.munki.recipe
+++ b/LoggerPro_Update/LoggerPro_Update.munki.recipe
@@ -24,16 +24,39 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%NAME%.pkg</string>
+				<string>%pathname%</string>
 				<key>pkginfo</key>
 				<dict>
 					<key>version</key>
 					<string>%dversion%</string>
+					<key>update_for</key>
+					<array>
+						<string>LoggerPro</string>
+					</array>
+					<key>installs</key>
+					<array>
+						<dict>
+							<key>CFBundleIdentifier</key>
+							<string>com.vernier.loggerpro</string>
+							<key>CFBundleName</key>
+							<string>Logger Pro</string>
+							<key>CFBundleShortVersionString</key>
+							<string>%dversion%</string>
+							<key>CFBundleVersion</key>
+							<string>%dversion%</string>
+							<key>path</key>
+							<string>/Applications/Logger Pro 3/Logger Pro.app</string>
+							<key>type</key>
+							<string>application</string>
+							<key>version_comparison_key</key>
+							<string>CFBundleShortVersionString</string>
+						</dict>
+					</array>
 				</dict>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 				<key>version_comparison_key</key>
-				<string>version</string>
+				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
The update uses receipts with version 0, so Munki thinks the update is already installed, so it needs an installs arrray

It also is an update for an already-installed Logger Pro, so I added a requires key.

For some reason, MunkiImporter was choking on the .pkg, so I changed it import the .dmg instead:
```
MunkiImporter: Traceback (most recent call last):
MunkiImporter:   File "/usr/local/munki/makepkginfo", line 1168, in <module>
MunkiImporter:     main()
MunkiImporter:   File "/usr/local/munki/makepkginfo", line 1146, in main
MunkiImporter:     item = catinfo['name']
MunkiImporter: KeyError: 'name'
creating pkginfo for LoggerPro_Update.pkg failed: Traceback (most recent call last):
  File "/usr/local/munki/makepkginfo", line 1168, in <module>
    main()
  File "/usr/local/munki/makepkginfo", line 1146, in main
    item = catinfo['name']
KeyError: 'name'
```

Also, the version comparison key failed without changing it o CFBundleVersion, so I changed that as well:

```
           'repo_subdirectory': u'LoggerPro_Update',
           'version_comparison_key': u'version'}}
version_comparison_key 'version' could not be found in the installs item for path '/Applications/Logger Pro 3/Logger Pro.app'
Failed.
```