### PR TITLE
Add EndOfCheckPhase processor

### DIFF
--- a/Aseba/Aseba.download.recipe
+++ b/Aseba/Aseba.download.recipe
@@ -42,6 +42,10 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>

--- a/LoggerPro_Update/LoggerPro_Update.download.recipe
+++ b/LoggerPro_Update/LoggerPro_Update.download.recipe
@@ -50,6 +50,10 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>


### PR DESCRIPTION
The EndOfCheckPhase processor allows administrators to use `autopkg run --check`, which is typically used to check for newly available software versions but not process any subsequent steps. It's typical to include the EndOfCheckPhase processor in most .download recipes.