### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/EclipseGyMo/EclipseMarsGyMo.pkg.recipe
+++ b/EclipseGyMo/EclipseMarsGyMo.pkg.recipe
@@ -91,9 +91,9 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>scripts</key>
 					<string>Eclipse_Scripts</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/Stellarium/Stellarium.pkg.recipe
+++ b/Stellarium/Stellarium.pkg.recipe
@@ -71,11 +71,11 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%dversion%</string>
+					<key>version</key>
+					<string>%dversion%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%dversion%</string>
-				<key>version</key>
-				<string>%dversion%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>


### PR DESCRIPTION
`pkgname` and `version` are [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).