### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Aseba/Aseba.pkg.recipe
+++ b/Aseba/Aseba.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLEID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>

--- a/EclipseGyMo/EclipseMarsGyMo.pkg.recipe
+++ b/EclipseGyMo/EclipseMarsGyMo.pkg.recipe
@@ -85,8 +85,6 @@
 					</array>
 					<key>id</key>
 					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>scripts</key>

--- a/LeJOS-EV3/LeJOS-EV3.pkg.recipe
+++ b/LeJOS-EV3/LeJOS-EV3.pkg.recipe
@@ -79,8 +79,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLEID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/LeJOS-NXJ/LeJOS-NXJ.pkg.recipe
+++ b/LeJOS-NXJ/LeJOS-NXJ.pkg.recipe
@@ -79,8 +79,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLEID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/Stellarium/Stellarium.pkg.recipe
+++ b/Stellarium/Stellarium.pkg.recipe
@@ -67,8 +67,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._